### PR TITLE
Update sitemap filter

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,8 +5,8 @@ export default defineConfig({
   integrations: [
     sitemap({
       filter: (page) =>
-        page.includes(".old") &&
-        page.includes("dumpster"),
+        !page.includes(".old") &&
+        !page.includes("dumpster"),
     })],
   site: 'https://headquarter8302.github.io',
   scopedStyleStrategy: 'class',


### PR DESCRIPTION
The sitemap filter now excludes pages that contain ".old" and "dumpster" instead of including them.